### PR TITLE
【js_modal.js】モーダルウィンドウを表示する

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -3,7 +3,7 @@ $(function(){
   var _global      = $(window);
   var _body        = $('body');
   var timer        = false;
-  var scrollTop;         // スクロール位置 記録用
+  var scrollTop;          // スクロール位置 記録用
   var DELAY_RESIZE = 200; // ウィンドウリサイズに、光を表示する時差
   var FADEIN_TIME  = 200; // フェードイン時間
   var FADEOUT_TIME = 200; // フェードアウト時間
@@ -14,7 +14,6 @@ $(function(){
   var modalInner   = ".modal-inner";
   var modalClose   = ".modal-close";
   var globalNav    = ".global-nav-wrapper";
-  var thumItem     = ".section-txt__sample-thum-item";
 
   // モーダルオープン時、ウィンドウをリサイズしたらサイズを調整
   window.addEventListener("resize", resizeModal, false);
@@ -31,52 +30,53 @@ $(function(){
     }, DELAY_RESIZE);
   }
 
-  // サムネイル画像押下時、bodyのスクロール禁止
-  $(document).on('click', thumItem, function() {
-    $(_body).addClass('enabled_modal');
-    $(globalNav).hide();
-    scrollTop = _global.scrollTop();
-    $(_body).css({
-      'position': 'fixed',
-      'width': '100%',
-      'overflow': 'hidden'
-    });
-  });
-
-  // 「xボタン」または、「閉じるボタン」押下時、bodyのスクロール禁止解除
-  $(document).on('click', modalClose, function() {
-    $(globalNav).fadeIn(FADEIN_TIME);
-    $(_body).css({
-      'position': 'relative',
-      'width': '',
-      'top': '',
-      'overflow': ''
-    });
-    $(_body).removeClass('enabled_modal');
-    _global.scrollTop(scrollTop);
-  });
-
-  // サムネイル画像押下時、モーダルを表示
+  // サムネイル画像押下時、モーダルを表示。または アローを押下時、モーダル内容を変更
   $(document).on('click', '[data-openmodal]', function(e) {
+    //モーダルをすでに表示しているかどうかで出し分け
+    if ($(this).data('openmodal-type') === "arrow") {
+      // すでに表示しているモーダルを隠す
+      $(modalOverlay).fadeOut(FADEOUT_TIME);
+    } else {
+      // グローバルナビを隠す
+      $(globalNav).hide();
+      //スクロール位置を記録
+      scrollTop = _global.scrollTop();
+      // bodyのスクロール禁止
+      $(_body).css({
+        'position': 'fixed',
+        'width'   : '100%',
+        'overflow': 'hidden'
+      });
+    }
+    // モーダル表示
     var _height = _global.height();
-    $(modalOverlay).fadeOut(FADEOUT_TIME);
-    var targetOpenModalId = $(this).attr('data-openmodal');
+    var targetOpenModalId  = $(this).data('openmodal');
     var $targetOpenOverlay = $('#' + targetOpenModalId);
-    var $targetOpenInner = $('#' + targetOpenModalId + ' ' + modalInner);
+    var $targetOpenInner   = $('#' + targetOpenModalId + ' ' + modalInner);
     $targetOpenOverlay.addClass('active-modal');
     $targetOpenOverlay.css({ 'height': _height + 'px' });
     $targetOpenInner.css({ 'height': (_height - ADJUST_HIGHT) + 'px' });
     $targetOpenOverlay.fadeIn(FADEIN_TIME);
-    $targetOpenInner.scrollTop(-1);
   });
 
   //「xボタン」または、「閉じるボタン」押下時、モーダルを非表示
   $(document).on('click', '[data-closemodal]', function(e) {
-    var targetCloseModalId = $(this).attr('data-closemodal');
+    // グローバルナビを表示
+    $(globalNav).fadeIn(FADEIN_TIME);
+    // bodyのスクロール禁止解除
+    $(_body).css({
+      'position': 'relative',
+      'width'   : '',
+      'top'     : '',
+      'overflow': ''
+    });
+    // スクロール位置を元に戻す
+    _global.scrollTop(scrollTop);
+    // モーダルを隠す
+    var targetCloseModalId  = $(this).data('closemodal');
     var $targetCloseOverlay = $('#' + targetCloseModalId);
-    var $targetCloseInner = $('#' + targetCloseModalId + ' ' + modalInner);
+    var $targetCloseInner   = $('#' + targetCloseModalId + ' ' + modalInner);
     $targetCloseOverlay.removeClass('active-modal');
-    $targetCloseInner.scrollTop(-1);
     $targetCloseOverlay.fadeOut(FADEOUT_TIME);
   });
 });

--- a/js/modal.js
+++ b/js/modal.js
@@ -3,7 +3,7 @@ $(function(){
   var _global      = $(window);
   var _body        = $('body');
   var timer        = false;
-  var currentScrollTop;          // スクロール位置 記録用
+  var currentScrollTop;   // スクロール位置 記録用
   var DELAY_RESIZE = 200; // ウィンドウリサイズ時に、光を表示する時差
   var FADEIN_TIME  = 200; // フェードイン時間
   var FADEOUT_TIME = 200; // フェードアウト時間

--- a/js/modal.js
+++ b/js/modal.js
@@ -3,8 +3,8 @@ $(function(){
   var _global      = $(window);
   var _body        = $('body');
   var timer        = false;
-  var scrollTop;          // スクロール位置 記録用
-  var DELAY_RESIZE = 200; // ウィンドウリサイズに、光を表示する時差
+  var currentScrollTop;          // スクロール位置 記録用
+  var DELAY_RESIZE = 200; // ウィンドウリサイズ時に、光を表示する時差
   var FADEIN_TIME  = 200; // フェードイン時間
   var FADEOUT_TIME = 200; // フェードアウト時間
   var ADJUST_HIGHT = 20;  // モーダル縦幅調整
@@ -14,8 +14,9 @@ $(function(){
   var modalInner   = ".modal-inner";
   var modalClose   = ".modal-close";
   var globalNav    = ".global-nav-wrapper";
+  var modalArrow   = ".modal-arrow";
 
-  // モーダルオープン時、ウィンドウをリサイズしたらサイズを調整
+  // ウィンドウリサイズ時、モーダルもリサイズ
   $(window).on('resize', function(){
     if (timer !== false) {
       clearTimeout(timer);
@@ -27,17 +28,30 @@ $(function(){
     }, DELAY_RESIZE);
   });
 
+  // arrowにカーソルが重なったら、arrowの色を変更
+  $(modalArrow).hover(function(){
+    $(this).addClass('hover');
+  },function(){
+    $(this).removeClass('hover');
+  });
+
   // サムネイル画像押下時、モーダルを表示。または アローを押下時、モーダル内容を変更
   $(document).on('click', '[data-openmodal]', function(e) {
-    // モーダルをarrowで開いたか、サムネイル画像で開いたかで出し分け
     if ($(this).data('openmodal-type') === "arrow") {
+      // モーダルをarrowで開いた場合
+      // 動画再生を止める
+      var $video = $('video');
+      for(var i = 0; i < video.length; i++){
+        $video[i].pause();
+      }
       // すでに表示しているモーダルを隠す
       $(modalOverlay).fadeOut(FADEOUT_TIME);
     } else {
+      // モーダルをサムネイル画像で開いた場合
       // グローバルナビを隠す
       $(globalNav).hide();
       //スクロール位置を記録
-      scrollTop = _global.scrollTop();
+      currentScrollTop = _global.scrollTop();
       // bodyのスクロール禁止
       $(_body).css({
         'position': 'fixed',
@@ -54,9 +68,11 @@ $(function(){
     $targetOpenOverlay.css({'height': _height + 'px'});
     $targetOpenInner.css({  'height': (_height - ADJUST_HIGHT) + 'px'});
     $targetOpenOverlay.fadeIn(FADEIN_TIME);
+    // モーダルウィンドウのスクロール位置をリセット
+    $targetOpenInner.scrollTop(0);
   });
 
-  //「xボタン」または、「閉じるボタン」押下時、モーダルを非表示
+  //「xボタン」または、「閉じるボタン」押下時、モーダルを隠す
   $(document).on('click', '[data-closemodal]', function(e) {
     // グローバルナビを表示
     $(globalNav).fadeIn(FADEIN_TIME);
@@ -67,12 +83,14 @@ $(function(){
       'overflow': ''
     });
     // スクロール位置を元に戻す
-    _global.scrollTop(scrollTop);
+    _global.scrollTop(currentScrollTop);
     // モーダルを隠す
     var targetCloseModalId  = $(this).data('closemodal');
     var $targetCloseOverlay = $('#' + targetCloseModalId);
     var $targetCloseInner   = $('#' + targetCloseModalId + ' ' + modalInner);
     $targetCloseOverlay.removeClass('active-modal');
     $targetCloseOverlay.fadeOut(FADEOUT_TIME);
+    // モーダルウィンドウのスクロール位置をリセット
+    $targetCloseInner.scrollTop(0);
   });
 });

--- a/js/modal.js
+++ b/js/modal.js
@@ -1,76 +1,82 @@
 $(function(){
   // 初期化
-  var timer = false;
-  var modalwindowHeight;
-  var scroll_top;
+  var _global      = $(window);
+  var _body        = $('body');
+  var timer        = false;
+  var scrollTop;         // スクロール位置 記録用
+  var DELAY_RESIZE = 200; // ウィンドウリサイズに、光を表示する時差
+  var FADEIN_TIME  = 200; // フェードイン時間
+  var FADEOUT_TIME = 200; // フェードアウト時間
+  var ADJUST_HIGHT = 20;  // モーダル縦幅調整
 
-  function getWindowHeight() {
-    modalwindowHeight = $(window).height();
-  }
+  // セレクタ
+  var modalOverlay = ".modal-overlay";
+  var modalInner   = ".modal-inner";
+  var modalClose   = ".modal-close";
+  var globalNav    = ".global-nav-wrapper";
+  var thumItem     = ".section-txt__sample-thum-item";
 
-  // ウィンドウリサイズ
-  $(window).on('resize', function(){
+  // モーダルオープン時、ウィンドウをリサイズしたらサイズを調整
+  window.addEventListener("resize", resizeModal, false);
+
+  // モーダルリサイズ
+  function resizeModal(){
     if (timer !== false) {
-        clearTimeout(timer);
+      clearTimeout(timer);
     }
     timer = setTimeout(function() {
-      getWindowHeight();
-      $('.modal-overlay').css('max-height', modalwindowHeight);
-      $('.modal-inner').css('max-height', modalwindowHeight + 80 + "px");
-    }, 200);
-  );
+      var _height = _global.height();
+      $(modalOverlay).css('height', _height);
+      $(modalInner).css('height', _height - ADJUST_HIGHT + "px");
+    }, DELAY_RESIZE);
+  }
 
-  // モーダルオープン時、スクロール禁止
-  var width = window.innerWidth - document.body.clientWidth;
-  var newStyle = document.createElement('style');
-  document.head.appendChild(newStyle);
-  newStyle.sheet.insertRule('body.enabled_modal { overflow: hidden; }', 0);
-
-  // モーダルオープン時、スクロール禁止解除
-  $(document).on('click', '.section-txt__sample-thum-item', function() {
-    $('body').addClass('enabled_modal');
-    $('.global-nav-wrapper').hide();
-    scroll_top = $(window).scrollTop();
-    $('body').css({
+  // サムネイル画像押下時、bodyのスクロール禁止
+  $(document).on('click', thumItem, function() {
+    $(_body).addClass('enabled_modal');
+    $(globalNav).hide();
+    scrollTop = _global.scrollTop();
+    $(_body).css({
       'position': 'fixed',
       'width': '100%',
-      'top': -scroll_top
+      'overflow': 'hidden'
     });
   });
 
-  // モーダルクローズ時、windowなどの処理
-  $(document).on('click', '.modal-close', function() {
-    $('.global-nav-wrapper').fadeIn(200);
-    $('body').css({
+  // 「xボタン」または、「閉じるボタン」押下時、bodyのスクロール禁止解除
+  $(document).on('click', modalClose, function() {
+    $(globalNav).fadeIn(FADEIN_TIME);
+    $(_body).css({
       'position': 'relative',
       'width': '',
-      'top': ''
+      'top': '',
+      'overflow': ''
     });
-    $('body').removeClass('enabled_modal');
-    $(window).scrollTop(scroll_top);
+    $(_body).removeClass('enabled_modal');
+    _global.scrollTop(scrollTop);
   });
 
-  // モーダルオープン時、内容を表示
+  // サムネイル画像押下時、モーダルを表示
   $(document).on('click', '[data-openmodal]', function(e) {
-    getWindowHeight();
-    $('.modal-overlay').fadeOut(200);
+    var _height = _global.height();
+    $(modalOverlay).fadeOut(FADEOUT_TIME);
     var targetOpenModalId = $(this).attr('data-openmodal');
     var $targetOpenOverlay = $('#' + targetOpenModalId);
-    var $targetOpenInner = $('#' + targetOpenModalId + ' .modal-inner');
+    var $targetOpenInner = $('#' + targetOpenModalId + ' ' + modalInner);
     $targetOpenOverlay.addClass('active-modal');
-    $targetOpenOverlay.css({ height: modalwindowHeight + 'px' });
-    $targetOpenInner.css({ height: (modalwindowHeight + 80) + 'px' });
-    $targetOpenOverlay.fadeIn(200);
+    $targetOpenOverlay.css({ 'height': _height + 'px' });
+    $targetOpenInner.css({ 'height': (_height - ADJUST_HIGHT) + 'px' });
+    $targetOpenOverlay.fadeIn(FADEIN_TIME);
     $targetOpenInner.scrollTop(-1);
   });
 
-  // モーダルクローズ時、内容を非表示
+  //「xボタン」または、「閉じるボタン」押下時、モーダルを非表示
   $(document).on('click', '[data-closemodal]', function(e) {
     var targetCloseModalId = $(this).attr('data-closemodal');
     var $targetCloseOverlay = $('#' + targetCloseModalId);
-    var $targetCloseInner = $('#' + targetCloseModalId + ' .modal-inner');
+    var $targetCloseInner = $('#' + targetCloseModalId + ' ' + modalInner);
     $targetCloseOverlay.removeClass('active-modal');
     $targetCloseInner.scrollTop(-1);
-    $targetCloseOverlay.fadeOut(200);
+    $targetCloseOverlay.fadeOut(FADEOUT_TIME);
   });
 });

--- a/js/modal.js
+++ b/js/modal.js
@@ -1,0 +1,76 @@
+$(function(){
+	// 初期化
+	var timer = false;
+  var modalwindowHeight;
+	var scroll_top;
+
+	function getWindowHeight() {
+		modalwindowHeight = $(window).height();
+	}
+
+	// ウィンドウリサイズ
+	$(window).on('resize', function(){
+		if (timer !== false) {
+				clearTimeout(timer);
+		}
+		timer = setTimeout(function() {
+			getWindowHeight();
+			$('.modal-overlay').css('max-height', modalwindowHeight);
+			$('.modal-inner').css('max-height', modalwindowHeight + 80 + "px");
+		}, 200);
+	});
+
+	// モーダルオープン時、スクロール禁止
+	var width = window.innerWidth - document.body.clientWidth;
+	var newStyle = document.createElement('style');
+	document.head.appendChild(newStyle);
+	newStyle.sheet.insertRule('body.enabled_modal { overflow: hidden; }', 0);
+
+	// モーダルオープン時、スクロール禁止解除
+	$(document).on('click', '.section-txt__sample-thum-item', function() {
+		$('body').addClass('enabled_modal');
+		$('.global-nav-wrapper').hide();
+		scroll_top = $(window).scrollTop();
+		$('body').css({
+			'position': 'fixed',
+			'width': '100%',
+			'top': -scroll_top
+		});
+	});
+
+	// モーダルクローズ時、windowなどの処理
+	$(document).on('click', '.modal-close', function() {
+		$('.global-nav-wrapper').fadeIn(200);
+		$('body').css({
+			'position': 'relative',
+			'width': '',
+			'top': ''
+		});
+		$('body').removeClass('enabled_modal');
+		$(window).scrollTop(scroll_top);
+	});
+
+	// モーダルオープン時、内容を表示
+  $(document).on('click', '[data-openmodal]', function(e) {
+		getWindowHeight();
+		$('.modal-overlay').fadeOut(200);
+	  var targetOpenModalId = $(this).attr('data-openmodal');
+	  var $targetOpenOverlay = $('#' + targetOpenModalId);
+	  var $targetOpenInner = $('#' + targetOpenModalId + ' .modal-inner');
+		$targetOpenOverlay.addClass('active-modal');
+	  $targetOpenOverlay.css({ height: modalwindowHeight + 'px' });
+	  $targetOpenInner.css({ height: (modalwindowHeight + 80) + 'px' });
+	  $targetOpenOverlay.fadeIn(200);
+		$targetOpenInner.scrollTop(-1);
+  });
+
+  // モーダルクローズ時、内容を非表示
+  $(document).on('click', '[data-closemodal]', function(e) {
+	  var targetCloseModalId = $(this).attr('data-closemodal');
+	  var $targetCloseOverlay = $('#' + targetCloseModalId);
+	  var $targetCloseInner = $('#' + targetCloseModalId + ' .modal-inner');
+		$targetCloseOverlay.removeClass('active-modal');
+		$targetCloseInner.scrollTop(-1);
+	  $targetCloseOverlay.fadeOut(200);
+  });
+});

--- a/js/modal.js
+++ b/js/modal.js
@@ -1,6 +1,11 @@
-$(function(){
+/*jslint browser: true*/
+/*global $, jQuery, alert*/
+
+$(function() {
   // 初期化
   var currentScrollTop,   // スクロール位置 記録用
+      activeModalIdNum,   // アクティブモーダルID 記録用
+      activeModalType,    // アクティブモーダルの種類 記録用
       timer        = false,
       DELAY_RESIZE = 200, // ウィンドウリサイズ時に、光を表示する時差
       FADEIN_TIME  = 200, // フェードイン時間
@@ -11,39 +16,31 @@ $(function(){
   var modalOverlay = ".modal-overlay",
       modalInner   = ".modal-inner",
       modalClose   = ".modal-close",
-      globalNav    = ".global-nav-wrapper",
-      modalArrow   = ".modal-arrow";
+      globalNav    = ".global-nav-wrapper";
 
   // DOM
-  var $_global      = $(window),
-      $_body        = $('body'),
+  var $window       = $(window),
+      $document     = $(document),
+      $body         = $('body'),
       $modalOverlay = $(modalOverlay),
       $modalInner   = $(modalInner),
       $modalClose   = $(modalClose),
-      $globalNav    = $(globalNav),
-      $modalArrow   = $(modalArrow);
+      $globalNav    = $(globalNav);
 
   // ウィンドウリサイズ時、モーダルもリサイズ
-  $_global.on('resize', function(){
+  $window.on('resize', function() {
     if (timer !== false) {
       clearTimeout(timer);
     }
     timer = setTimeout(function() {
-      var _height = $_global.height();
+      var _height = $window.height();
       $modalOverlay.css('height', _height);
       $modalInner.css(  'height', _height - ADJUST_HIGHT + "px");
     }, DELAY_RESIZE);
   });
 
-  // arrowにカーソルが重なったら、arrowの色を変更
-  $(modalArrow).hover(function(){
-    $(this).addClass('hover');
-  },function(){
-    $(this).removeClass('hover');
-  });
-
   // サムネイル画像押下時、モーダルを表示。または アローを押下時、モーダル内容を変更
-  $(document).on('click', '[data-openmodal]', function(e) {
+  $document.on('click', '[data-openmodal]', function(e) {
     if ($(this).data('openmodal-type') === "arrow") {
       // モーダルをarrowで開いた場合
       // 動画再生を止める
@@ -58,46 +55,81 @@ $(function(){
       // グローバルナビを隠す
       $globalNav.hide();
       //スクロール位置を記録
-      currentScrollTop = $_global.scrollTop();
+      currentScrollTop = $window.scrollTop();
       // bodyのスクロール禁止
-      $($_body).css({
+      $body.css({
         'position': 'fixed',
         'width'   : '100%',
         'overflow': 'hidden'
       });
     }
     // モーダル表示
-    var _height = $_global.height();
-    var targetOpenModalId  = $(this).data('openmodal');
-    var $targetOpenOverlay = $('#' + targetOpenModalId);
-    var $targetOpenInner   = $('#' + targetOpenModalId + ' ' + modalInner);
+    var _height = $window.height();
+        targetOpenModalName  = $(this).data('openmodal'),
+        $targetOpenOverlay   = $('#' + targetOpenModalName),
+        $targetOpenInner     = $('#' + targetOpenModalName + ' ' + modalInner);
     $targetOpenOverlay.addClass('active-modal');
     $targetOpenOverlay.css({'height': _height + 'px'});
     $targetOpenInner.css({  'height': (_height - ADJUST_HIGHT) + 'px'});
     $targetOpenOverlay.fadeIn(FADEIN_TIME);
+
+    // arrowの生成
+    var activeModalIdNum   = targetOpenModalName.slice(-1),
+        activeModalName    = targetOpenModalName.slice(0,-1),
+        activeModalTypeNum = $('.' + activeModalType).length;
+        prevModalIdNum     = (Number(activeModalIdNum)-1),
+        nextModalIdNum     = (Number(activeModalIdNum)+1),
+        prevModalName      = activeModalName + prevModalIdNum,
+        nextModalName      = activeModalName + nextModalIdNum,
+        min                = 1,
+        max                = (Number($('.' + activeModalName).length));
+    if(activeModalIdNum <= max && activeModalIdNum > min) {
+      $targetOpenOverlay.find('.section-title').prepend(
+        '<div class="modal-arrow arrow-box arrow-left" ' +
+        'data-openmodal="' + prevModalName + '" data-openmodal-type="arrow"></div>'
+      );
+    }
+    if(activeModalIdNum >= min && activeModalIdNum < max) {
+      $targetOpenOverlay.find('.section-title').prepend(
+        '<div class="modal-arrow arrow-box arrow-right" ' +
+        'data-openmodal="' + nextModalName + '" data-openmodal-type="arrow"></div>'
+      );
+    }
+
     // モーダルウィンドウのスクロール位置をリセット
     $targetOpenInner.scrollTop(0);
   });
 
   //「xボタン」または、「閉じるボタン」押下時、モーダルを隠す
-  $(document).on('click', '[data-closemodal]', function(e) {
+  $document.on('click', '[data-closemodal]', function(e) {
     // グローバルナビを表示
-    $globalNav.fadeIn(FADEIN_TIME);
+    $globalNav.fadeIn
+    (FADEIN_TIME);
     // bodyのスクロール禁止解除
-    $($_body).css({
+    $body.css({
       'position': 'relative',
       'width'   : '',
       'overflow': ''
     });
     // スクロール位置を元に戻す
-    $_global.scrollTop(currentScrollTop);
+    $window.scrollTop(currentScrollTop);
     // モーダルを隠す
-    var targetCloseModalId  = $(this).data('closemodal');
-    var $targetCloseOverlay = $('#' + targetCloseModalId);
-    var $targetCloseInner   = $('#' + targetCloseModalId + ' ' + modalInner);
+    var targetCloseModalName  = $(this).data('closemodal'),
+        $targetCloseOverlay = $('#' + targetCloseModalName),
+        $targetCloseInner   = $('#' + targetCloseModalName + ' ' + modalInner);
     $targetCloseOverlay.removeClass('active-modal');
     $targetCloseOverlay.fadeOut(FADEOUT_TIME);
     // モーダルウィンドウのスクロール位置をリセット
     $targetCloseInner.scrollTop(0);
   });
+
+  // arrowにカーソルが重なったら、arrowの色を変更。
+  // 後からappendした要素のhoverは、この描き方じゃないと動かない。
+  $(document).on('mouseenter','.modal-arrow',function() {
+    $(this).addClass('hover');
+  });
+  $(document).on('mouseleave','.modal-arrow',function() {
+    $(this).removeClass('hover');
+  });
+
 });

--- a/js/modal.js
+++ b/js/modal.js
@@ -1,76 +1,76 @@
 $(function(){
-	// 初期化
-	var timer = false;
+  // 初期化
+  var timer = false;
   var modalwindowHeight;
-	var scroll_top;
+  var scroll_top;
 
-	function getWindowHeight() {
-		modalwindowHeight = $(window).height();
-	}
+  function getWindowHeight() {
+    modalwindowHeight = $(window).height();
+  }
 
-	// ウィンドウリサイズ
-	$(window).on('resize', function(){
-		if (timer !== false) {
-				clearTimeout(timer);
-		}
-		timer = setTimeout(function() {
-			getWindowHeight();
-			$('.modal-overlay').css('max-height', modalwindowHeight);
-			$('.modal-inner').css('max-height', modalwindowHeight + 80 + "px");
-		}, 200);
-	});
+  // ウィンドウリサイズ
+  $(window).on('resize', function(){
+    if (timer !== false) {
+        clearTimeout(timer);
+    }
+    timer = setTimeout(function() {
+      getWindowHeight();
+      $('.modal-overlay').css('max-height', modalwindowHeight);
+      $('.modal-inner').css('max-height', modalwindowHeight + 80 + "px");
+    }, 200);
+  );
 
-	// モーダルオープン時、スクロール禁止
-	var width = window.innerWidth - document.body.clientWidth;
-	var newStyle = document.createElement('style');
-	document.head.appendChild(newStyle);
-	newStyle.sheet.insertRule('body.enabled_modal { overflow: hidden; }', 0);
+  // モーダルオープン時、スクロール禁止
+  var width = window.innerWidth - document.body.clientWidth;
+  var newStyle = document.createElement('style');
+  document.head.appendChild(newStyle);
+  newStyle.sheet.insertRule('body.enabled_modal { overflow: hidden; }', 0);
 
-	// モーダルオープン時、スクロール禁止解除
-	$(document).on('click', '.section-txt__sample-thum-item', function() {
-		$('body').addClass('enabled_modal');
-		$('.global-nav-wrapper').hide();
-		scroll_top = $(window).scrollTop();
-		$('body').css({
-			'position': 'fixed',
-			'width': '100%',
-			'top': -scroll_top
-		});
-	});
+  // モーダルオープン時、スクロール禁止解除
+  $(document).on('click', '.section-txt__sample-thum-item', function() {
+    $('body').addClass('enabled_modal');
+    $('.global-nav-wrapper').hide();
+    scroll_top = $(window).scrollTop();
+    $('body').css({
+      'position': 'fixed',
+      'width': '100%',
+      'top': -scroll_top
+    });
+  });
 
-	// モーダルクローズ時、windowなどの処理
-	$(document).on('click', '.modal-close', function() {
-		$('.global-nav-wrapper').fadeIn(200);
-		$('body').css({
-			'position': 'relative',
-			'width': '',
-			'top': ''
-		});
-		$('body').removeClass('enabled_modal');
-		$(window).scrollTop(scroll_top);
-	});
+  // モーダルクローズ時、windowなどの処理
+  $(document).on('click', '.modal-close', function() {
+    $('.global-nav-wrapper').fadeIn(200);
+    $('body').css({
+      'position': 'relative',
+      'width': '',
+      'top': ''
+    });
+    $('body').removeClass('enabled_modal');
+    $(window).scrollTop(scroll_top);
+  });
 
-	// モーダルオープン時、内容を表示
+  // モーダルオープン時、内容を表示
   $(document).on('click', '[data-openmodal]', function(e) {
-		getWindowHeight();
-		$('.modal-overlay').fadeOut(200);
-	  var targetOpenModalId = $(this).attr('data-openmodal');
-	  var $targetOpenOverlay = $('#' + targetOpenModalId);
-	  var $targetOpenInner = $('#' + targetOpenModalId + ' .modal-inner');
-		$targetOpenOverlay.addClass('active-modal');
-	  $targetOpenOverlay.css({ height: modalwindowHeight + 'px' });
-	  $targetOpenInner.css({ height: (modalwindowHeight + 80) + 'px' });
-	  $targetOpenOverlay.fadeIn(200);
-		$targetOpenInner.scrollTop(-1);
+    getWindowHeight();
+    $('.modal-overlay').fadeOut(200);
+    var targetOpenModalId = $(this).attr('data-openmodal');
+    var $targetOpenOverlay = $('#' + targetOpenModalId);
+    var $targetOpenInner = $('#' + targetOpenModalId + ' .modal-inner');
+    $targetOpenOverlay.addClass('active-modal');
+    $targetOpenOverlay.css({ height: modalwindowHeight + 'px' });
+    $targetOpenInner.css({ height: (modalwindowHeight + 80) + 'px' });
+    $targetOpenOverlay.fadeIn(200);
+    $targetOpenInner.scrollTop(-1);
   });
 
   // モーダルクローズ時、内容を非表示
   $(document).on('click', '[data-closemodal]', function(e) {
-	  var targetCloseModalId = $(this).attr('data-closemodal');
-	  var $targetCloseOverlay = $('#' + targetCloseModalId);
-	  var $targetCloseInner = $('#' + targetCloseModalId + ' .modal-inner');
-		$targetCloseOverlay.removeClass('active-modal');
-		$targetCloseInner.scrollTop(-1);
-	  $targetCloseOverlay.fadeOut(200);
+    var targetCloseModalId = $(this).attr('data-closemodal');
+    var $targetCloseOverlay = $('#' + targetCloseModalId);
+    var $targetCloseInner = $('#' + targetCloseModalId + ' .modal-inner');
+    $targetCloseOverlay.removeClass('active-modal');
+    $targetCloseInner.scrollTop(-1);
+    $targetCloseOverlay.fadeOut(200);
   });
 });

--- a/js/modal.js
+++ b/js/modal.js
@@ -45,7 +45,7 @@ $(function() {
     stopVideo: function() {
       // 動画再生を止める
       var $video = $('video');
-      for(var i = 0; i < $video.length; i++){
+      for(var i = 0; i < video.length; i++){
         $video[i].pause();
       }
     }
@@ -136,8 +136,7 @@ $(function() {
 
   // arrowにカーソルが重なったら、arrowの色を変更。
   // 後からappendした要素のhoverは、この描き方じゃないと動かない。
-  var $modalArrow = $(modalArrow);
-  $(document).on('mouseenter',$modalArrow,function() {
+  $(document).on('mouseenter',modalArrow,function() {
     $(this).addClass('hover');
   });
   $(document).on('mouseleave',$modalArrow,function() {

--- a/js/modal.js
+++ b/js/modal.js
@@ -26,13 +26,13 @@ $(function(){
     timer = setTimeout(function() {
       var _height = _global.height();
       $(modalOverlay).css('height', _height);
-      $(modalInner).css('height', _height - ADJUST_HIGHT + "px");
+      $(modalInner).css(  'height', _height - ADJUST_HIGHT + "px");
     }, DELAY_RESIZE);
   }
 
   // サムネイル画像押下時、モーダルを表示。または アローを押下時、モーダル内容を変更
   $(document).on('click', '[data-openmodal]', function(e) {
-    //モーダルをすでに表示しているかどうかで出し分け
+    // モーダルをarrowで開いたか、サムネイル画像で開いたかで出し分け
     if ($(this).data('openmodal-type') === "arrow") {
       // すでに表示しているモーダルを隠す
       $(modalOverlay).fadeOut(FADEOUT_TIME);
@@ -54,8 +54,8 @@ $(function(){
     var $targetOpenOverlay = $('#' + targetOpenModalId);
     var $targetOpenInner   = $('#' + targetOpenModalId + ' ' + modalInner);
     $targetOpenOverlay.addClass('active-modal');
-    $targetOpenOverlay.css({ 'height': _height + 'px' });
-    $targetOpenInner.css({ 'height': (_height - ADJUST_HIGHT) + 'px' });
+    $targetOpenOverlay.css({'height': _height + 'px'});
+    $targetOpenInner.css({  'height': (_height - ADJUST_HIGHT) + 'px'});
     $targetOpenOverlay.fadeIn(FADEIN_TIME);
   });
 

--- a/js/modal.js
+++ b/js/modal.js
@@ -1,30 +1,37 @@
 $(function(){
   // 初期化
-  var _global      = $(window);
-  var _body        = $('body');
-  var timer        = false;
-  var currentScrollTop;   // スクロール位置 記録用
-  var DELAY_RESIZE = 200; // ウィンドウリサイズ時に、光を表示する時差
-  var FADEIN_TIME  = 200; // フェードイン時間
-  var FADEOUT_TIME = 200; // フェードアウト時間
-  var ADJUST_HIGHT = 20;  // モーダル縦幅調整
+  var currentScrollTop,   // スクロール位置 記録用
+      timer        = false,
+      DELAY_RESIZE = 200, // ウィンドウリサイズ時に、光を表示する時差
+      FADEIN_TIME  = 200, // フェードイン時間
+      FADEOUT_TIME = 200, // フェードアウト時間
+      ADJUST_HIGHT = 20;  // モーダル縦幅調整
 
   // セレクタ
-  var modalOverlay = ".modal-overlay";
-  var modalInner   = ".modal-inner";
-  var modalClose   = ".modal-close";
-  var globalNav    = ".global-nav-wrapper";
-  var modalArrow   = ".modal-arrow";
+  var modalOverlay = ".modal-overlay",
+      modalInner   = ".modal-inner",
+      modalClose   = ".modal-close",
+      globalNav    = ".global-nav-wrapper",
+      modalArrow   = ".modal-arrow";
+
+  // DOM
+  var $_global      = $(window),
+      $_body        = $('body'),
+      $modalOverlay = $(modalOverlay),
+      $modalInner   = $(modalInner),
+      $modalClose   = $(modalClose),
+      $globalNav    = $(globalNav),
+      $modalArrow   = $(modalArrow);
 
   // ウィンドウリサイズ時、モーダルもリサイズ
-  _global.on('resize', function(){
+  $_global.on('resize', function(){
     if (timer !== false) {
       clearTimeout(timer);
     }
     timer = setTimeout(function() {
-      var _height = _global.height();
-      $(modalOverlay).css('height', _height);
-      $(modalInner).css(  'height', _height - ADJUST_HIGHT + "px");
+      var _height = $_global.height();
+      $modalOverlay.css('height', _height);
+      $modalInner.css(  'height', _height - ADJUST_HIGHT + "px");
     }, DELAY_RESIZE);
   });
 
@@ -45,22 +52,22 @@ $(function(){
         $video[i].pause();
       }
       // すでに表示しているモーダルを隠す
-      $(modalOverlay).fadeOut(FADEOUT_TIME);
+      $modalOverlay.fadeOut(FADEOUT_TIME);
     } else {
       // モーダルをサムネイル画像で開いた場合
       // グローバルナビを隠す
-      $(globalNav).hide();
+      $globalNav.hide();
       //スクロール位置を記録
-      currentScrollTop = _global.scrollTop();
+      currentScrollTop = $_global.scrollTop();
       // bodyのスクロール禁止
-      $(_body).css({
+      $($_body).css({
         'position': 'fixed',
         'width'   : '100%',
         'overflow': 'hidden'
       });
     }
     // モーダル表示
-    var _height = _global.height();
+    var _height = $_global.height();
     var targetOpenModalId  = $(this).data('openmodal');
     var $targetOpenOverlay = $('#' + targetOpenModalId);
     var $targetOpenInner   = $('#' + targetOpenModalId + ' ' + modalInner);
@@ -75,15 +82,15 @@ $(function(){
   //「xボタン」または、「閉じるボタン」押下時、モーダルを隠す
   $(document).on('click', '[data-closemodal]', function(e) {
     // グローバルナビを表示
-    $(globalNav).fadeIn(FADEIN_TIME);
+    $globalNav.fadeIn(FADEIN_TIME);
     // bodyのスクロール禁止解除
-    $(_body).css({
+    $($_body).css({
       'position': 'relative',
       'width'   : '',
       'overflow': ''
     });
     // スクロール位置を元に戻す
-    _global.scrollTop(currentScrollTop);
+    $_global.scrollTop(currentScrollTop);
     // モーダルを隠す
     var targetCloseModalId  = $(this).data('closemodal');
     var $targetCloseOverlay = $('#' + targetCloseModalId);

--- a/js/modal.js
+++ b/js/modal.js
@@ -16,6 +16,7 @@ $(function() {
   var modalOverlay = ".modal-overlay",
       modalInner   = ".modal-inner",
       modalClose   = ".modal-close",
+      modalArrow   = ".modal-arrow",
       globalNav    = ".global-nav-wrapper";
 
   // DOM
@@ -39,15 +40,23 @@ $(function() {
     }, DELAY_RESIZE);
   });
 
+  // 共通関数
+  var generalFnc = {
+    stopVideo: function() {
+      // 動画再生を止める
+      var $video = $('video');
+      for(var i = 0; i < $video.length; i++){
+        $video[i].pause();
+      }
+    }
+  }
+
   // サムネイル画像押下時、モーダルを表示。または アローを押下時、モーダル内容を変更
   $document.on('click', '[data-openmodal]', function(e) {
     if ($(this).data('openmodal-type') === "arrow") {
       // モーダルをarrowで開いた場合
       // 動画再生を止める
-      var $video = $('video');
-      for(var i = 0; i < video.length; i++){
-        $video[i].pause();
-      }
+      generalFnc.stopVideo();
       // すでに表示しているモーダルを隠す
       $modalOverlay.fadeOut(FADEOUT_TIME);
     } else {
@@ -121,14 +130,17 @@ $(function() {
     $targetCloseOverlay.fadeOut(FADEOUT_TIME);
     // モーダルウィンドウのスクロール位置をリセット
     $targetCloseInner.scrollTop(0);
+    // 動画再生を止める
+    generalFnc.stopVideo();
   });
 
   // arrowにカーソルが重なったら、arrowの色を変更。
   // 後からappendした要素のhoverは、この描き方じゃないと動かない。
-  $(document).on('mouseenter','.modal-arrow',function() {
+  var $modalArrow = $(modalArrow);
+  $(document).on('mouseenter',$modalArrow,function() {
     $(this).addClass('hover');
   });
-  $(document).on('mouseleave','.modal-arrow',function() {
+  $(document).on('mouseleave',$modalArrow,function() {
     $(this).removeClass('hover');
   });
 

--- a/js/modal.js
+++ b/js/modal.js
@@ -139,7 +139,7 @@ $(function() {
   $(document).on('mouseenter',modalArrow,function() {
     $(this).addClass('hover');
   });
-  $(document).on('mouseleave',$modalArrow,function() {
+  $(document).on('mouseleave',modalArrow,function() {
     $(this).removeClass('hover');
   });
 

--- a/js/modal.js
+++ b/js/modal.js
@@ -67,7 +67,6 @@ $(function(){
     $(_body).css({
       'position': 'relative',
       'width'   : '',
-      'top'     : '',
       'overflow': ''
     });
     // スクロール位置を元に戻す

--- a/js/modal.js
+++ b/js/modal.js
@@ -15,7 +15,7 @@ $(function() {
       modalInner   = ".modal-inner",        // モーダルインナー
       modalClose   = ".modal-close",        // モーダルクローズトリガー
       modalArrow   = ".modal-arrow",　      // arrow要素
-      sectionTitle   = ".section-title",    // arrowを配置する要素
+      sectionTitle = ".section-title",      // arrowを配置する要素
       globalNav    = ".global-nav-wrapper"; // グローバルナビ
 
   // DOM
@@ -112,8 +112,7 @@ $(function() {
   //「xボタン」または、「閉じるボタン」押下時、モーダルを隠す
   $document.on('click', '[data-closemodal]', function(e) {
     // グローバルナビを表示
-    $globalNav.fadeIn
-    (FADEIN_TIME);
+    $globalNav.fadeIn(FADEIN_TIME);
     // bodyのスクロール禁止解除
     $body.css({
       'position': 'relative',

--- a/js/modal.js
+++ b/js/modal.js
@@ -13,11 +13,12 @@ $(function() {
       ADJUST_HIGHT = 20;  // モーダル縦幅調整
 
   // セレクタ
-  var modalOverlay = ".modal-overlay",
-      modalInner   = ".modal-inner",
-      modalClose   = ".modal-close",
-      modalArrow   = ".modal-arrow",
-      globalNav    = ".global-nav-wrapper";
+  var modalOverlay = ".modal-overlay",      // 黒いモーダル背景
+      modalInner   = ".modal-inner",        // モーダルインナー
+      modalClose   = ".modal-close",        // モーダルクローズトリガー
+      modalArrow   = ".modal-arrow",　      // arrow要素
+      sectionTitle   = ".section-title",    // arrowを配置する要素
+      globalNav    = ".global-nav-wrapper"; // グローバルナビ
 
   // DOM
   var $window       = $(window),
@@ -93,13 +94,13 @@ $(function() {
         min                = 1,
         max                = (Number($('.' + activeModalName).length));
     if(activeModalIdNum <= max && activeModalIdNum > min) {
-      $targetOpenOverlay.find('.section-title').prepend(
+      $targetOpenOverlay.find(sectionTitle).prepend(
         '<div class="modal-arrow arrow-box arrow-left" ' +
         'data-openmodal="' + prevModalName + '" data-openmodal-type="arrow"></div>'
       );
     }
     if(activeModalIdNum >= min && activeModalIdNum < max) {
-      $targetOpenOverlay.find('.section-title').prepend(
+      $targetOpenOverlay.find(sectionTitle).prepend(
         '<div class="modal-arrow arrow-box arrow-right" ' +
         'data-openmodal="' + nextModalName + '" data-openmodal-type="arrow"></div>'
       );

--- a/js/modal.js
+++ b/js/modal.js
@@ -1,16 +1,14 @@
-/*jslint browser: true*/
-/*global $, jQuery, alert*/
-
 $(function() {
+
   // 初期化
-  var currentScrollTop,   // スクロール位置 記録用
-      activeModalIdNum,   // アクティブモーダルID 記録用
-      activeModalType,    // アクティブモーダルの種類 記録用
-      timer        = false,
-      DELAY_RESIZE = 200, // ウィンドウリサイズ時に、光を表示する時差
-      FADEIN_TIME  = 200, // フェードイン時間
-      FADEOUT_TIME = 200, // フェードアウト時間
-      ADJUST_HIGHT = 20;  // モーダル縦幅調整
+  var currentScrollTop,      // スクロール位置 記録用
+      activeModalIdNum,      // アクティブモーダルID 記録用
+      activeModalType,       // アクティブモーダルの種類 記録用
+      timer        = false,  // 時差用
+      DELAY_RESIZE = 200,    // ウィンドウリサイズ時に、光を表示する時差
+      FADEIN_TIME  = 200,    // フェードイン時間
+      FADEOUT_TIME = 200,    // フェードアウト時間
+      ADJUST_HIGHT = 20;     // モーダル縦幅調整
 
   // セレクタ
   var modalOverlay = ".modal-overlay",      // 黒いモーダル背景
@@ -46,7 +44,7 @@ $(function() {
     stopVideo: function() {
       // 動画再生を止める
       var $video = $('video');
-      for(var i = 0; i < video.length; i++){
+      for(var i = 0; i < $video.length; i++){
         $video[i].pause();
       }
     }
@@ -73,6 +71,7 @@ $(function() {
         'overflow': 'hidden'
       });
     }
+
     // モーダル表示
     var _height = $window.height();
         targetOpenModalName  = $(this).data('openmodal'),
@@ -136,7 +135,7 @@ $(function() {
   });
 
   // arrowにカーソルが重なったら、arrowの色を変更。
-  // 後からappendした要素のhoverは、この描き方じゃないと動かない。
+  // 後から追加した要素のhoverは、この描き方じゃないと動かない。
   $(document).on('mouseenter',modalArrow,function() {
     $(this).addClass('hover');
   });

--- a/js/modal.js
+++ b/js/modal.js
@@ -17,7 +17,7 @@ $(function(){
   var modalArrow   = ".modal-arrow";
 
   // ウィンドウリサイズ時、モーダルもリサイズ
-  $(window).on('resize', function(){
+  _global.on('resize', function(){
     if (timer !== false) {
       clearTimeout(timer);
     }

--- a/js/modal.js
+++ b/js/modal.js
@@ -16,10 +16,7 @@ $(function(){
   var globalNav    = ".global-nav-wrapper";
 
   // モーダルオープン時、ウィンドウをリサイズしたらサイズを調整
-  window.addEventListener("resize", resizeModal, false);
-
-  // モーダルリサイズ
-  function resizeModal(){
+  $(window).on('resize', function(){
     if (timer !== false) {
       clearTimeout(timer);
     }
@@ -28,7 +25,7 @@ $(function(){
       $(modalOverlay).css('height', _height);
       $(modalInner).css(  'height', _height - ADJUST_HIGHT + "px");
     }, DELAY_RESIZE);
-  }
+  });
 
   // サムネイル画像押下時、モーダルを表示。または アローを押下時、モーダル内容を変更
   $(document).on('click', '[data-openmodal]', function(e) {


### PR DESCRIPTION
# 概要
jQueryを使い、サムネイル画像をクリックすると、全画面のモーダルウィンドウを表示する。

# やったこと
- サムネイル画像をクリックすると、モーダルウィンドウを表示。
- モーダルウィンドウを表示後、カテゴリに複数属する物があれば、
左右の矢印で表示内容を切り替えられる。
- モーダルウィンドウを表示後、「ｘボタン」または「閉じるボタン」で
モーダルウィンドウを閉じる。
- モーダルウィンドウを表示後、ウィンドウの縦幅・横幅を変更したら、
モーダルウィンドウの大きさを調整する。
- モーダルウィンドウを表示後、モーダルウィンドウ内はスクロール可能だが、
body側はスクロールしない。

# レビューして欲しい所
- もっと効率のよい書き方はないか
- ロジックに問題はないか
